### PR TITLE
Refactor flashcard generation logic into shared helper

### DIFF
--- a/src/document_to_anki/core/flashcard_generator.py
+++ b/src/document_to_anki/core/flashcard_generator.py
@@ -5,6 +5,8 @@ This module provides the FlashcardGenerator class that orchestrates the creation
 editing, and management of flashcards using the LLMClient and Flashcard models.
 """
 
+import asyncio
+import inspect
 import time
 from pathlib import Path
 from typing import Any
@@ -64,162 +66,106 @@ class FlashcardGenerator:
     def flashcards(self) -> list[Flashcard]:
         """Get the current list of flashcards."""
         return self._flashcards.copy()
+    async def _generate_flashcards_common(
+        self,
+        text_content: str | list[str],
+        source_files: list[str] | None,
+        generator_func: Any,
+    ) -> ProcessingResult:
+        """
+        Shared implementation for generating flashcards.
+
+        Args:
+            text_content: List of text strings to process.
+            source_files: Optional list of source file names corresponding to text_content.
+            generator_func: Function used to generate flashcards for a single text chunk.
+                This may be a synchronous or asynchronous callable.
+        """
+        start_time = time.time()
+        all_flashcards: list[Flashcard] = []
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        # Normalize input: accept a single string or a list of strings
+        if isinstance(text_content, str):
+            text_chunks: list[str] = [text_content]
+        else:
+            text_chunks = text_content
+
+        if not text_chunks:
+            errors.append("No text content provided for flashcard generation")
+            return ProcessingResult(
+                flashcards=[],
+                source_files=source_files or [],
+                processing_time=time.time() - start_time,
+                errors=errors,
+                warnings=warnings,
+            )
+
+        logger.info(f"Starting flashcard generation for {len(text_chunks)} text chunks")
+
+        # Process each text chunk
+        for i, text in enumerate(text_chunks):
+            if not text or not text.strip():
+                warnings.append(f"Skipping empty text chunk {i + 1}")
+                continue
+
+            try:
+                source_file = source_files[i] if source_files and i < len(source_files) else None
+                result = generator_func(text, source_file, i + 1, warnings)
+                if inspect.isawaitable(result):
+                    chunk_flashcards = await result
+                else:
+                    chunk_flashcards = result
+                all_flashcards.extend(chunk_flashcards)
+
+            except Exception as e:
+                error_msg = f"Failed to generate flashcards from text chunk {i + 1}: {str(e)}"
+                logger.error(error_msg)
+                errors.append(error_msg)
+                continue
+
+        # Validate generated flashcards
+        valid_flashcards = []
+        for flashcard in all_flashcards:
+            if flashcard.validate_content():
+                valid_flashcards.append(flashcard)
+            else:
+                warnings.append(f"Invalid flashcard generated: {flashcard.question[:50]}...")
+
+        # Update internal flashcard list
+        self._flashcards = valid_flashcards
+
+        processing_time = time.time() - start_time
+
+        result = ProcessingResult(
+            flashcards=valid_flashcards,
+            source_files=source_files or [],
+            processing_time=processing_time,
+            errors=errors,
+            warnings=warnings,
+        )
+
+        logger.info(f"Flashcard generation completed: {result.get_summary()}")
+        return result
 
     async def generate_flashcards_async(
         self, text_content: str | list[str], source_files: list[str] | None = None
     ) -> ProcessingResult:
-        """
-        Generate flashcards from text content using LLM (async version).
-
-        Args:
-            text_content: List of text strings to process
-            source_files: Optional list of source file names corresponding to text_content
-
-        Returns:
-            ProcessingResult containing generated flashcards and processing metadata
-        """
-        start_time = time.time()
-        all_flashcards = []
-        errors = []
-        warnings: list[str] = []
-
-        # Normalize input: accept a single string or a list of strings
-        if isinstance(text_content, str):
-            text_chunks: list[str] = [text_content]
-        else:
-            text_chunks = text_content
-
-        if not text_chunks:
-            errors.append("No text content provided for flashcard generation")
-            return ProcessingResult(
-                flashcards=[],
-                source_files=source_files or [],
-                processing_time=time.time() - start_time,
-                errors=errors,
-                warnings=warnings,
-            )
-
-        logger.info(f"Starting flashcard generation for {len(text_chunks)} text chunks")
-
-        # Process each text chunk
-        for i, text in enumerate(text_chunks):
-            if not text or not text.strip():
-                warnings.append(f"Skipping empty text chunk {i + 1}")
-                continue
-
-            try:
-                source_file = source_files[i] if source_files and i < len(source_files) else None
-                chunk_flashcards = await self._generate_flashcards_from_single_text_async(
-                    text, source_file, i + 1, warnings
-                )
-                all_flashcards.extend(chunk_flashcards)
-
-            except Exception as e:
-                error_msg = f"Failed to generate flashcards from text chunk {i + 1}: {str(e)}"
-                logger.error(error_msg)
-                errors.append(error_msg)
-                continue
-
-        # Validate generated flashcards
-        valid_flashcards = []
-        for flashcard in all_flashcards:
-            if flashcard.validate_content():
-                valid_flashcards.append(flashcard)
-            else:
-                warnings.append(f"Invalid flashcard generated: {flashcard.question[:50]}...")
-
-        # Update internal flashcard list
-        self._flashcards = valid_flashcards
-
-        processing_time = time.time() - start_time
-
-        result = ProcessingResult(
-            flashcards=valid_flashcards,
-            source_files=source_files or [],
-            processing_time=processing_time,
-            errors=errors,
-            warnings=warnings,
+        """Generate flashcards from text content using LLM (async version)."""
+        return await self._generate_flashcards_common(
+            text_content, source_files, self._generate_flashcards_from_single_text_async
         )
-
-        logger.info(f"Flashcard generation completed: {result.get_summary()}")
-        return result
 
     def generate_flashcards(
         self, text_content: str | list[str], source_files: list[str] | None = None
     ) -> ProcessingResult:
-        """
-        Generate flashcards from text content using LLM.
-
-        Args:
-            text_content: List of text strings to process
-            source_files: Optional list of source file names corresponding to text_content
-
-        Returns:
-            ProcessingResult containing generated flashcards and processing metadata
-        """
-        start_time = time.time()
-        all_flashcards = []
-        errors = []
-        warnings: list[str] = []
-
-        # Normalize input: accept a single string or a list of strings
-        if isinstance(text_content, str):
-            text_chunks: list[str] = [text_content]
-        else:
-            text_chunks = text_content
-
-        if not text_chunks:
-            errors.append("No text content provided for flashcard generation")
-            return ProcessingResult(
-                flashcards=[],
-                source_files=source_files or [],
-                processing_time=time.time() - start_time,
-                errors=errors,
-                warnings=warnings,
+        """Generate flashcards from text content using LLM."""
+        return asyncio.run(
+            self._generate_flashcards_common(
+                text_content, source_files, self._generate_flashcards_from_single_text
             )
-
-        logger.info(f"Starting flashcard generation for {len(text_chunks)} text chunks")
-
-        # Process each text chunk
-        for i, text in enumerate(text_chunks):
-            if not text or not text.strip():
-                warnings.append(f"Skipping empty text chunk {i + 1}")
-                continue
-
-            try:
-                source_file = source_files[i] if source_files and i < len(source_files) else None
-                chunk_flashcards = self._generate_flashcards_from_single_text(text, source_file, i + 1, warnings)
-                all_flashcards.extend(chunk_flashcards)
-
-            except Exception as e:
-                error_msg = f"Failed to generate flashcards from text chunk {i + 1}: {str(e)}"
-                logger.error(error_msg)
-                errors.append(error_msg)
-                continue
-
-        # Validate generated flashcards
-        valid_flashcards = []
-        for flashcard in all_flashcards:
-            if flashcard.validate_content():
-                valid_flashcards.append(flashcard)
-            else:
-                warnings.append(f"Invalid flashcard generated: {flashcard.question[:50]}...")
-
-        # Update internal flashcard list
-        self._flashcards = valid_flashcards
-
-        processing_time = time.time() - start_time
-
-        result = ProcessingResult(
-            flashcards=valid_flashcards,
-            source_files=source_files or [],
-            processing_time=processing_time,
-            errors=errors,
-            warnings=warnings,
         )
-
-        logger.info(f"Flashcard generation completed: {result.get_summary()}")
-        return result
 
     async def _generate_flashcards_from_single_text_async(
         self, text: str, source_file: str | None, chunk_number: int, warnings: list[str] | None = None

--- a/tests/test_flashcard_generator.py
+++ b/tests/test_flashcard_generator.py
@@ -91,6 +91,23 @@ class TestFlashcardGenerator:
         assert flashcards[0].card_type == "qa"
         assert flashcards[0].source_file == "test.txt"
 
+    @pytest.mark.asyncio
+    async def test_generate_flashcards_async_success(
+        self, generator, mock_llm_client, sample_flashcard_data, mocker
+    ):
+        """Test successful async flashcard generation."""
+        mock_llm_client.generate_flashcards_from_text = mocker.AsyncMock(
+            return_value=sample_flashcard_data
+        )
+
+        text_content = ["Sample text content"]
+        source_files = ["test.txt"]
+        result = await generator.generate_flashcards_async(text_content, source_files)
+
+        assert result.success
+        assert len(result.flashcards) == 2
+        assert result.source_files == source_files
+
     def test_generate_flashcards_empty_content(self, generator):
         """Test flashcard generation with empty content."""
         result = generator.generate_flashcards([])


### PR DESCRIPTION
## Summary
- Extract shared logic from `generate_flashcards_async` and `generate_flashcards` into `_generate_flashcards_common`
- Delegate async/sync public methods to the common helper
- Add test ensuring async flashcard generation path is exercised

## Testing
- `pytest tests/test_flashcard_generator.py::TestFlashcardGenerator::test_generate_flashcards_success -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68ade72a52388325b24d834e5b88937d