### PR TITLE
refactor: modularize text extraction utilities

### DIFF
--- a/src/document_to_anki/utils/docx_extractor.py
+++ b/src/document_to_anki/utils/docx_extractor.py
@@ -1,0 +1,53 @@
+"""DOCX text extraction utilities."""
+
+from pathlib import Path
+
+from docx import Document
+from loguru import logger
+
+from .text_extractor_common import TextExtractionError
+
+
+def extract_text(file_path: Path) -> str:
+    """Extract text from a DOCX file using python-docx."""
+    try:
+        doc = Document(str(file_path))
+        text_content: list[str] = []
+
+        for paragraph in doc.paragraphs:
+            if paragraph.text.strip():
+                text_content.append(paragraph.text)
+
+        for table in doc.tables:
+            for row in table.rows:
+                row_text = []
+                for cell in row.cells:
+                    if cell.text.strip():
+                        row_text.append(cell.text.strip())
+                if row_text:
+                    text_content.append(" | ".join(row_text))
+
+        extracted_text = "\n\n".join(text_content)
+        if not extracted_text.strip():
+            logger.warning(f"No text content extracted from DOCX: {file_path}")
+            return ""
+
+        logger.info(f"Successfully extracted text from DOCX: {file_path}")
+        return extracted_text
+    except FileNotFoundError as e:
+        raise TextExtractionError(f"DOCX file not found: {file_path}") from e
+    except PermissionError as e:
+        raise TextExtractionError(
+            f"Permission denied accessing DOCX file: {file_path}"
+        ) from e
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "not a zip file" in error_msg or "bad zipfile" in error_msg:
+            raise TextExtractionError(
+                f"Invalid or corrupted DOCX file: {file_path}"
+            ) from e
+        if "no such file" in error_msg:
+            raise TextExtractionError(f"DOCX file not found: {file_path}") from e
+        raise TextExtractionError(
+            f"Unexpected error extracting from DOCX {file_path}: {str(e)}"
+        ) from e

--- a/src/document_to_anki/utils/pdf_extractor.py
+++ b/src/document_to_anki/utils/pdf_extractor.py
@@ -1,0 +1,148 @@
+"""PDF text extraction utilities."""
+
+from pathlib import Path
+
+from loguru import logger
+from pypdf import PdfReader
+
+from .text_extractor_common import TextExtractionError
+
+try:
+    import pdfplumber
+
+    HAS_PDFPLUMBER = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAS_PDFPLUMBER = False
+
+
+def extract_text(file_path: Path) -> str:
+    """Extract text from a PDF file using pypdf.
+
+    Args:
+        file_path: Path to the PDF file
+
+    Returns:
+        Extracted text content as a string
+
+    Raises:
+        TextExtractionError: If PDF extraction fails
+    """
+    try:
+        text_content = []
+        with open(file_path, "rb") as file:
+            try:
+                pdf_reader = PdfReader(file)
+            except Exception as reader_error:
+                file.seek(0)
+                try:
+                    pdf_reader = PdfReader(file)
+                except Exception as fallback_error:
+                    if HAS_PDFPLUMBER:
+                        logger.warning(
+                            f"PyPDF failed for {file_path}, trying pdfplumber..."
+                        )
+                        return _extract_with_pdfplumber(file_path)
+                    raise TextExtractionError(
+                        f"Could not initialize PDF reader for {file_path}. "
+                        f"The PDF may be severely corrupted or use an unsupported format. "
+                        f"Original error: {reader_error}, Fallback error: {fallback_error}"
+                    ) from fallback_error
+
+            if pdf_reader.is_encrypted:
+                raise TextExtractionError(f"PDF file is encrypted: {file_path}")
+            if len(pdf_reader.pages) == 0:
+                logger.warning(f"PDF file has no pages: {file_path}")
+                return ""
+
+            successful_pages = 0
+            for page_num, page in enumerate(pdf_reader.pages):
+                try:
+                    page_text = page.extract_text()
+                    if page_text and page_text.strip():
+                        text_content.append(page_text)
+                        successful_pages += 1
+                except (AttributeError, TypeError) as e:
+                    logger.warning(
+                        f"Skipping malformed page {page_num + 1} in {file_path}: {e}"
+                    )
+                    continue
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        f"Failed to extract text from page {page_num + 1} in {file_path}: {e}"
+                    )
+                    continue
+
+            extracted_text = "\n\n".join(text_content)
+            if not extracted_text.strip():
+                if successful_pages == 0:
+                    raise TextExtractionError(
+                        f"No text content could be extracted from PDF: {file_path}. "
+                        f"The PDF may be image-based, corrupted, or use unsupported formatting."
+                    )
+                logger.warning(f"No text content extracted from PDF: {file_path}")
+                return ""
+
+            logger.info(
+                f"Successfully extracted text from PDF: {file_path} "
+                f"({successful_pages}/{len(pdf_reader.pages)} pages processed)"
+            )
+            return extracted_text
+    except FileNotFoundError as e:
+        raise TextExtractionError(f"PDF file not found: {file_path}") from e
+    except PermissionError as e:
+        raise TextExtractionError(
+            f"Permission denied accessing PDF file: {file_path}"
+        ) from e
+    except Exception as e:
+        error_msg = str(e)
+        if "PdfReadError" in error_msg:
+            raise TextExtractionError(
+                f"Invalid or corrupted PDF file: {file_path} - {error_msg}"
+            ) from e
+        raise TextExtractionError(
+            f"Unexpected error extracting from PDF {file_path}: {error_msg}"
+        ) from e
+
+
+def _extract_with_pdfplumber(file_path: Path) -> str:
+    """Extract text using pdfplumber as a fallback method."""
+    if not HAS_PDFPLUMBER:
+        raise TextExtractionError("pdfplumber is not available")
+    try:
+        text_content = []
+        with pdfplumber.open(file_path) as pdf:
+            if len(pdf.pages) == 0:
+                logger.warning(f"PDF file has no pages: {file_path}")
+                return ""
+            successful_pages = 0
+            for page_num, page in enumerate(pdf.pages):
+                try:
+                    page_text = page.extract_text()
+                    if page_text and page_text.strip():
+                        text_content.append(page_text)
+                        successful_pages += 1
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        f"pdfplumber failed to extract text from page {page_num + 1} in {file_path}: {e}"
+                    )
+                    continue
+            extracted_text = "\n\n".join(text_content)
+            if not extracted_text.strip():
+                if successful_pages == 0:
+                    raise TextExtractionError(
+                        f"No text content could be extracted from PDF using pdfplumber: {file_path}. "
+                        f"The PDF may be image-based or use unsupported formatting."
+                    )
+                logger.warning(
+                    f"No text content extracted from PDF using pdfplumber: {file_path}"
+                )
+                return ""
+            logger.info(
+                f"Successfully extracted text from PDF using pdfplumber: {file_path} "
+                f"({successful_pages}/{len(pdf.pages)} pages processed)"
+            )
+            return extracted_text
+    except Exception as e:
+        raise TextExtractionError(
+            f"pdfplumber extraction failed for {file_path}: {str(e)}"
+        ) from e

--- a/src/document_to_anki/utils/pptx_extractor.py
+++ b/src/document_to_anki/utils/pptx_extractor.py
@@ -1,0 +1,99 @@
+"""PPTX text extraction utilities."""
+
+from pathlib import Path
+
+from loguru import logger
+
+from .text_extractor_common import TextExtractionError
+
+try:
+    from pptx import Presentation
+
+    HAS_PPTX = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAS_PPTX = False
+
+
+def extract_text(file_path: Path) -> str:
+    """Extract text from a PowerPoint presentation using python-pptx."""
+    if not HAS_PPTX:
+        raise TextExtractionError(
+            "python-pptx is not available. Install it with: pip install python-pptx"
+        )
+    try:
+        presentation = Presentation(str(file_path))
+        extracted_text: list[str] = []
+        if len(presentation.slides) == 0:
+            logger.warning(f"PowerPoint presentation has no slides: {file_path}")
+            return ""
+        successful_slides = 0
+        for slide_num, slide in enumerate(presentation.slides, 1):
+            try:
+                slide_content = [f"=== Slide {slide_num} ==="]
+                for shape in slide.shapes:
+                    if hasattr(shape, "text") and shape.text.strip():
+                        text = _clean_slide_text(shape.text)
+                        if text:
+                            slide_content.append(text)
+                if len(slide_content) > 1:
+                    extracted_text.extend(slide_content)
+                    extracted_text.append("")
+                    successful_slides += 1
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    f"Failed to extract text from slide {slide_num} in {file_path}: {e}"
+                )
+                continue
+        final_text = "\n".join(extracted_text).strip()
+        if not final_text:
+            if successful_slides == 0:
+                raise TextExtractionError(
+                    f"No text content could be extracted from PowerPoint: {file_path}. "
+                    f"The presentation may contain only images or unsupported content."
+                )
+            logger.warning(
+                f"No text content extracted from PowerPoint: {file_path}"
+            )
+            return ""
+        logger.info(
+            f"Successfully extracted text from PowerPoint: {file_path} "
+            f"({successful_slides}/{len(presentation.slides)} slides processed)"
+        )
+        return final_text
+    except FileNotFoundError as e:
+        raise TextExtractionError(f"PowerPoint file not found: {file_path}") from e
+    except PermissionError as e:
+        raise TextExtractionError(
+            f"Permission denied accessing PowerPoint file: {file_path}"
+        ) from e
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "not a zip file" in error_msg or "bad zipfile" in error_msg:
+            raise TextExtractionError(
+                f"Invalid or corrupted PowerPoint file: {file_path}"
+            ) from e
+        if "password" in error_msg or "encrypted" in error_msg:
+            raise TextExtractionError(
+                f"Password-protected PowerPoint file: {file_path}"
+            ) from e
+        if "no such file" in error_msg or "package not found" in error_msg:
+            raise TextExtractionError(f"PowerPoint file not found: {file_path}") from e
+        raise TextExtractionError(
+            f"Unexpected error extracting from PowerPoint {file_path}: {str(e)}"
+        ) from e
+
+
+def _clean_slide_text(text: str) -> str:
+    """Clean and format slide text while preserving structure."""
+    if not text or not text.strip():
+        return ""
+    lines = text.split("\n")
+    cleaned_lines = []
+    for line in lines:
+        cleaned_line = line.strip()
+        cleaned_lines.append(cleaned_line)
+    import re
+
+    cleaned_text = "\n".join(cleaned_lines)
+    cleaned_text = re.sub(r"\n{3,}", "\n\n", cleaned_text)
+    return cleaned_text.strip()

--- a/src/document_to_anki/utils/text_extractor.py
+++ b/src/document_to_anki/utils/text_extractor.py
@@ -2,485 +2,57 @@
 
 from pathlib import Path
 
-from docx import Document
 from loguru import logger
-from pypdf import PdfReader
 
-try:
-    from pptx import Presentation
-
-    HAS_PPTX = True
-except ImportError:
-    HAS_PPTX = False
-
-try:
-    import pdfplumber
-
-    HAS_PDFPLUMBER = True
-except ImportError:
-    HAS_PDFPLUMBER = False
-
-
-class TextExtractionError(Exception):
-    """Exception raised when text extraction fails."""
-
-    pass
+from . import docx_extractor, pdf_extractor, pptx_extractor, text_extractor_common
+from .text_extractor_common import TextExtractionError
 
 
 class TextExtractor:
     """Handles text extraction from various document formats."""
 
     SUPPORTED_FORMATS = {".pdf", ".docx", ".pptx", ".txt", ".md"}
+    _EXTRACTOR_MAP = {
+        ".pdf": pdf_extractor.extract_text,
+        ".docx": docx_extractor.extract_text,
+        ".pptx": pptx_extractor.extract_text,
+        ".txt": text_extractor_common.extract_text,
+        ".md": text_extractor_common.extract_text,
+    }
 
     def __init__(self) -> None:
         """Initialize the TextExtractor."""
         self.logger = logger
 
     def extract_text(self, file_path: Path) -> str:
-        """
-        Extract text from a file based on its extension.
-
-        Args:
-            file_path: Path to the file to extract text from
-
-        Returns:
-            Extracted text content as a string
-
-        Raises:
-            TextExtractionError: If extraction fails or format is unsupported
-        """
+        """Extract text from a file based on its extension."""
         if not file_path.exists():
             raise TextExtractionError(f"File does not exist: {file_path}")
-
         if not file_path.is_file():
             raise TextExtractionError(f"Path is not a file: {file_path}")
 
         file_extension = file_path.suffix.lower()
-
-        if file_extension not in self.SUPPORTED_FORMATS:
+        extractor = self._EXTRACTOR_MAP.get(file_extension)
+        if extractor is None:
             raise TextExtractionError(
                 f"Unsupported file format: {file_extension}. Supported formats: {', '.join(self.SUPPORTED_FORMATS)}"
             )
-
         try:
-            if file_extension == ".pdf":
-                return self.extract_text_from_pdf(file_path)
-            elif file_extension == ".docx":
-                return self.extract_text_from_docx(file_path)
-            elif file_extension == ".pptx":
-                return self.extract_text_from_pptx(file_path)
-            elif file_extension in {".txt", ".md"}:
-                return self.extract_text_from_txt(file_path)
-            else:
-                raise TextExtractionError(f"Unsupported file format: {file_extension}")
-
+            return extractor(file_path)
         except Exception as e:
             if isinstance(e, TextExtractionError):
                 raise
-            raise TextExtractionError(f"Failed to extract text from {file_path}: {str(e)}") from e
-
-    def extract_text_from_pdf(self, file_path: Path) -> str:
-        """
-        Extract text from a PDF file using pypdf.
-
-        Args:
-            file_path: Path to the PDF file
-
-        Returns:
-            Extracted text content as a string
-
-        Raises:
-            TextExtractionError: If PDF extraction fails
-        """
-        try:
-            text_content = []
-
-            with open(file_path, "rb") as file:
-                # Use strict=False to handle malformed PDFs more gracefully
-                try:
-                    pdf_reader = PdfReader(file)
-                except Exception as reader_error:
-                    # If PyPDF fails completely, try with different settings
-                    self.logger.warning(f"Initial PDF reader failed for {file_path}: {reader_error}")
-                    file.seek(0)  # Reset file pointer
-                    try:
-                        # Try with even more lenient settings
-                        pdf_reader = PdfReader(file)
-                    except Exception as fallback_error:
-                        # If PyPDF fails completely, try pdfplumber as last resort
-                        if HAS_PDFPLUMBER:
-                            self.logger.warning(f"PyPDF failed for {file_path}, trying pdfplumber...")
-                            return self._extract_with_pdfplumber(file_path)
-                        else:
-                            raise TextExtractionError(
-                                f"Could not initialize PDF reader for {file_path}. "
-                                f"The PDF may be severely corrupted or use an unsupported format. "
-                                f"Original error: {reader_error}, Fallback error: {fallback_error}"
-                            ) from fallback_error
-
-                # Check if PDF is encrypted
-                if pdf_reader.is_encrypted:
-                    raise TextExtractionError(f"PDF file is encrypted: {file_path}")
-
-                # Check if PDF has pages
-                if len(pdf_reader.pages) == 0:
-                    self.logger.warning(f"PDF file has no pages: {file_path}")
-                    return ""
-
-                # Extract text from each page with enhanced error handling
-                successful_pages = 0
-                for page_num, page in enumerate(pdf_reader.pages):
-                    try:
-                        page_text = page.extract_text()
-                        if page_text and page_text.strip():  # Only add non-empty pages
-                            text_content.append(page_text)
-                            successful_pages += 1
-                    except (AttributeError, TypeError) as e:
-                        # Handle NullObject and similar errors
-                        self.logger.warning(f"Skipping malformed page {page_num + 1} in {file_path}: {e}")
-                        continue
-                    except Exception as e:
-                        self.logger.warning(f"Failed to extract text from page {page_num + 1} in {file_path}: {e}")
-                        continue
-
-                extracted_text = "\n\n".join(text_content)
-
-                if not extracted_text.strip():
-                    if successful_pages == 0:
-                        raise TextExtractionError(
-                            f"No text content could be extracted from PDF: {file_path}. "
-                            f"The PDF may be image-based, corrupted, or use unsupported formatting."
-                        )
-                    else:
-                        self.logger.warning(f"No text content extracted from PDF: {file_path}")
-                        return ""
-
-                self.logger.info(
-                    f"Successfully extracted text from PDF: {file_path} "
-                    f"({successful_pages}/{len(pdf_reader.pages)} pages processed)"
-                )
-                return extracted_text
-
-        except FileNotFoundError as e:
-            raise TextExtractionError(f"PDF file not found: {file_path}") from e
-        except PermissionError as e:
-            raise TextExtractionError(f"Permission denied accessing PDF file: {file_path}") from e
-        except Exception as e:
-            # Handle pypdf specific errors
-            if "PdfReadError" in str(type(e)) or "PDF" in str(e):
-                raise TextExtractionError(f"Invalid or corrupted PDF file: {file_path} - {str(e)}") from e
-            raise TextExtractionError(f"Unexpected error extracting from PDF {file_path}: {str(e)}") from e
-
-    def _extract_with_pdfplumber(self, file_path: Path) -> str:
-        """
-        Extract text using pdfplumber as a fallback method.
-
-        Args:
-            file_path: Path to the PDF file
-
-        Returns:
-            Extracted text content as a string
-
-        Raises:
-            TextExtractionError: If pdfplumber extraction fails
-        """
-        if not HAS_PDFPLUMBER:
-            raise TextExtractionError("pdfplumber is not available")
-
-        try:
-            text_content = []
-
-            with pdfplumber.open(file_path) as pdf:
-                if len(pdf.pages) == 0:
-                    self.logger.warning(f"PDF file has no pages: {file_path}")
-                    return ""
-
-                successful_pages = 0
-                for page_num, page in enumerate(pdf.pages):
-                    try:
-                        page_text = page.extract_text()
-                        if page_text and page_text.strip():
-                            text_content.append(page_text)
-                            successful_pages += 1
-                    except Exception as e:
-                        self.logger.warning(
-                            f"pdfplumber failed to extract text from page {page_num + 1} in {file_path}: {e}"
-                        )
-                        continue
-
-                extracted_text = "\n\n".join(text_content)
-
-                if not extracted_text.strip():
-                    if successful_pages == 0:
-                        raise TextExtractionError(
-                            f"No text content could be extracted from PDF using pdfplumber: {file_path}. "
-                            f"The PDF may be image-based or use unsupported formatting."
-                        )
-                    else:
-                        self.logger.warning(f"No text content extracted from PDF using pdfplumber: {file_path}")  # noqa: E501
-                        return ""
-
-                self.logger.info(
-                    f"Successfully extracted text from PDF using pdfplumber: {file_path} "
-                    f"({successful_pages}/{len(pdf.pages)} pages processed)"
-                )
-                return extracted_text
-
-        except Exception as e:
-            raise TextExtractionError(f"pdfplumber extraction failed for {file_path}: {str(e)}") from e
-
-    def extract_text_from_docx(self, file_path: Path) -> str:
-        """
-        Extract text from a DOCX file using python-docx.
-
-        Args:
-            file_path: Path to the DOCX file
-
-        Returns:
-            Extracted text content as a string
-
-        Raises:
-            TextExtractionError: If DOCX extraction fails
-        """
-        try:
-            doc = Document(str(file_path))
-            text_content = []
-
-            # Extract text from paragraphs
-            for paragraph in doc.paragraphs:
-                if paragraph.text.strip():  # Only add non-empty paragraphs
-                    text_content.append(paragraph.text)
-
-            # Extract text from tables
-            for table in doc.tables:
-                for row in table.rows:
-                    row_text = []
-                    for cell in row.cells:
-                        if cell.text.strip():
-                            row_text.append(cell.text.strip())
-                    if row_text:
-                        text_content.append(" | ".join(row_text))
-
-            extracted_text = "\n\n".join(text_content)
-
-            if not extracted_text.strip():
-                self.logger.warning(f"No text content extracted from DOCX: {file_path}")
-                return ""
-
-            self.logger.info(f"Successfully extracted text from DOCX: {file_path}")
-            return extracted_text
-
-        except FileNotFoundError as e:
-            raise TextExtractionError(f"DOCX file not found: {file_path}") from e
-        except PermissionError as e:
-            raise TextExtractionError(f"Permission denied accessing DOCX file: {file_path}") from e
-        except Exception as e:
-            # Handle various docx-related errors
-            error_msg = str(e).lower()
-            if "not a zip file" in error_msg or "bad zipfile" in error_msg:
-                raise TextExtractionError(f"Invalid or corrupted DOCX file: {file_path}") from e
-            elif "no such file" in error_msg:
-                raise TextExtractionError(f"DOCX file not found: {file_path}") from e
-            else:
-                raise TextExtractionError(f"Unexpected error extracting from DOCX {file_path}: {str(e)}") from e
-
-    def extract_text_from_txt(self, file_path: Path) -> str:
-        """
-        Extract text from a TXT or MD file.
-
-        Args:
-            file_path: Path to the text file
-
-        Returns:
-            Extracted text content as a string
-
-        Raises:
-            TextExtractionError: If text extraction fails
-        """
-        try:
-            # Try different encodings in order of preference
-            encodings = ["utf-8", "utf-8-sig", "latin-1", "cp1252"]
-
-            for encoding in encodings:
-                try:
-                    with open(file_path, encoding=encoding) as file:
-                        content = file.read()
-
-                    if not content.strip():
-                        self.logger.warning(f"Text file is empty: {file_path}")
-                        return ""
-
-                    self.logger.info(
-                        f"Successfully extracted text from {file_path.suffix.upper()} file: {file_path} "
-                        f"(encoding: {encoding})"
-                    )
-                    return content
-
-                except UnicodeDecodeError:
-                    continue  # Try next encoding
-
-            # If all encodings failed
-            raise TextExtractionError(f"Could not decode text file with any supported encoding: {file_path}")
-
-        except FileNotFoundError as e:
-            raise TextExtractionError(f"Text file not found: {file_path}") from e
-        except PermissionError as e:
-            raise TextExtractionError(f"Permission denied accessing text file: {file_path}") from e
-        except Exception as e:
-            raise TextExtractionError(f"Unexpected error extracting from text file {file_path}: {str(e)}") from e
-
-    def extract_text_from_pptx(self, file_path: Path) -> str:
-        """
-        Extract text from a PowerPoint presentation using python-pptx.
-
-        Args:
-            file_path: Path to the PPTX file
-
-        Returns:
-            Extracted text content as a string with slide structure preserved
-
-        Raises:
-            TextExtractionError: If PPTX extraction fails
-        """
-        if not HAS_PPTX:
-            raise TextExtractionError("python-pptx is not available. Install it with: pip install python-pptx")
-
-        try:
-            presentation = Presentation(str(file_path))
-            extracted_text = []
-
-            # Check if presentation has slides
-            if len(presentation.slides) == 0:
-                self.logger.warning(f"PowerPoint presentation has no slides: {file_path}")
-                return ""
-
-            successful_slides = 0
-            for slide_num, slide in enumerate(presentation.slides, 1):
-                try:
-                    slide_content = [f"=== Slide {slide_num} ==="]
-
-                    # Extract text from all shapes in the slide
-                    for shape in slide.shapes:
-                        if hasattr(shape, "text") and shape.text.strip():
-                            # Clean and preserve structure with bullet points and formatting
-                            text = self._clean_slide_text(shape.text)
-                            if text:
-                                slide_content.append(text)
-
-                    # Only add slides that have content beyond the header
-                    if len(slide_content) > 1:
-                        extracted_text.extend(slide_content)
-                        extracted_text.append("")  # Add spacing between slides
-                        successful_slides += 1
-
-                except Exception as e:
-                    self.logger.warning(f"Failed to extract text from slide {slide_num} in {file_path}: {e}")
-                    continue
-
-            final_text = "\n".join(extracted_text).strip()
-
-            if not final_text:
-                if successful_slides == 0:
-                    raise TextExtractionError(
-                        f"No text content could be extracted from PowerPoint: {file_path}. "
-                        f"The presentation may contain only images or unsupported content."
-                    )
-                else:
-                    self.logger.warning(f"No text content extracted from PowerPoint: {file_path}")
-                    return ""
-
-            self.logger.info(
-                f"Successfully extracted text from PowerPoint: {file_path} "
-                f"({successful_slides}/{len(presentation.slides)} slides processed)"
-            )
-            return final_text
-
-        except FileNotFoundError as e:
-            raise TextExtractionError(f"PowerPoint file not found: {file_path}") from e
-        except PermissionError as e:
-            raise TextExtractionError(f"Permission denied accessing PowerPoint file: {file_path}") from e
-        except Exception as e:
-            # Handle various pptx-related errors
-            error_msg = str(e).lower()
-            if "not a zip file" in error_msg or "bad zipfile" in error_msg:
-                raise TextExtractionError(f"Invalid or corrupted PowerPoint file: {file_path}") from e
-            elif "password" in error_msg or "encrypted" in error_msg:
-                raise TextExtractionError(f"Password-protected PowerPoint file: {file_path}") from e
-            elif "no such file" in error_msg or "package not found" in error_msg:
-                raise TextExtractionError(f"PowerPoint file not found: {file_path}") from e
-            else:
-                raise TextExtractionError(f"Unexpected error extracting from PowerPoint {file_path}: {str(e)}") from e
-
-    def _clean_slide_text(self, text: str) -> str:
-        """
-        Clean and format slide text while preserving structure.
-
-        Args:
-            text: Raw text from a slide shape
-
-        Returns:
-            Cleaned text with preserved structure
-
-        """
-        if not text or not text.strip():
-            return ""
-
-        # Split into lines and process each line
-        lines = text.split("\n")
-        cleaned_lines = []
-
-        for line in lines:
-            cleaned_line = line.strip()
-            # Keep both empty and non-empty lines to preserve structure
-            cleaned_lines.append(cleaned_line)
-
-        # Join lines back together
-        cleaned_text = "\n".join(cleaned_lines)
-
-        # Remove multiple consecutive newlines but preserve intentional line breaks
-        import re
-
-        cleaned_text = re.sub(r"\n{3,}", "\n\n", cleaned_text)
-
-        # Remove leading and trailing whitespace from the entire text
-        cleaned_text = cleaned_text.strip()
-
-        return cleaned_text
-
-    def extract_text_from_md(self, file_path: Path) -> str:
-        """
-        Extract text from a Markdown file.
-
-        This is an alias for extract_text_from_txt since both are plain text files.
-
-        Args:
-            file_path: Path to the markdown file
-
-        Returns:
-            Extracted text content as a string
-
-        Raises:
-            TextExtractionError: If text extraction fails
-        """
-        return self.extract_text_from_txt(file_path)
+            raise TextExtractionError(
+                f"Failed to extract text from {file_path}: {str(e)}"
+            ) from e
 
     def is_supported_format(self, file_path: Path) -> bool:
-        """
-        Check if a file format is supported for text extraction.
-
-        Args:
-            file_path: Path to the file to check
-
-        Returns:
-            True if the file format is supported, False otherwise
-        """
+        """Check if a file format is supported for text extraction."""
         return file_path.suffix.lower() in self.SUPPORTED_FORMATS
 
     def get_supported_formats(self) -> set[str]:
-        """
-        Get the set of supported file formats.
-
-        Returns:
-            Set of supported file extensions (including the dot)
-        """
+        """Get the set of supported file formats."""
         return self.SUPPORTED_FORMATS.copy()
+
+
+__all__ = ["TextExtractor", "TextExtractionError"]

--- a/src/document_to_anki/utils/text_extractor_common.py
+++ b/src/document_to_anki/utils/text_extractor_common.py
@@ -1,0 +1,56 @@
+"""Common utilities for text extraction."""
+
+from pathlib import Path
+
+from loguru import logger
+
+
+class TextExtractionError(Exception):
+    """Exception raised when text extraction fails."""
+
+    pass
+
+
+def extract_text(file_path: Path) -> str:
+    """Extract text from a plain text or markdown file.
+
+    Tries multiple encodings before giving up.
+
+    Args:
+        file_path: Path to the text file
+
+    Returns:
+        Extracted text content as a string
+
+    Raises:
+        TextExtractionError: If text extraction fails
+    """
+    try:
+        encodings = ["utf-8", "utf-8-sig", "latin-1", "cp1252"]
+        for encoding in encodings:
+            try:
+                with open(file_path, encoding=encoding) as file:
+                    content = file.read()
+                if not content.strip():
+                    logger.warning(f"Text file is empty: {file_path}")
+                    return ""
+                logger.info(
+                    f"Successfully extracted text from {file_path.suffix.upper()} file: {file_path} "
+                    f"(encoding: {encoding})"
+                )
+                return content
+            except UnicodeDecodeError:
+                continue
+        raise TextExtractionError(
+            f"Could not decode text file with any supported encoding: {file_path}"
+        )
+    except FileNotFoundError as e:
+        raise TextExtractionError(f"Text file not found: {file_path}") from e
+    except PermissionError as e:
+        raise TextExtractionError(
+            f"Permission denied accessing text file: {file_path}"
+        ) from e
+    except Exception as e:
+        raise TextExtractionError(
+            f"Unexpected error extracting from text file {file_path}: {str(e)}"
+        ) from e

--- a/tests/test_text_extractor.py
+++ b/tests/test_text_extractor.py
@@ -6,6 +6,10 @@ from pathlib import Path
 import pytest
 
 from src.document_to_anki.utils import TextExtractionError, TextExtractor
+import src.document_to_anki.utils.pdf_extractor as pdf_extractor
+import src.document_to_anki.utils.docx_extractor as docx_extractor
+import src.document_to_anki.utils.pptx_extractor as pptx_extractor
+import src.document_to_anki.utils.text_extractor_common as text_extractor_common
 
 
 class TestTextExtractor:
@@ -58,7 +62,7 @@ class TestTextExtractor:
             tmp.write(test_content)
             tmp.flush()
 
-            result = self.extractor.extract_text_from_txt(Path(tmp.name))
+            result = text_extractor_common.extract_text(Path(tmp.name))
             assert result == test_content
 
         # Clean up
@@ -70,7 +74,7 @@ class TestTextExtractor:
             tmp.write("")
             tmp.flush()
 
-            result = self.extractor.extract_text_from_txt(Path(tmp.name))
+            result = text_extractor_common.extract_text(Path(tmp.name))
             assert result == ""
 
         # Clean up
@@ -79,7 +83,7 @@ class TestTextExtractor:
     def test_extract_text_from_txt_file_not_found(self):
         """Test extraction from non-existent TXT file."""
         with pytest.raises(TextExtractionError, match="Text file not found"):
-            self.extractor.extract_text_from_txt(Path("nonexistent.txt"))
+            text_extractor_common.extract_text(Path("nonexistent.txt"))
 
     def test_extract_text_from_md_alias(self):
         """Test that extract_text_from_md is an alias for extract_text_from_txt."""
@@ -89,7 +93,7 @@ class TestTextExtractor:
             tmp.write(test_content)
             tmp.flush()
 
-            result = self.extractor.extract_text_from_md(Path(tmp.name))
+            result = text_extractor_common.extract_text(Path(tmp.name))
             assert result == test_content
 
         # Clean up
@@ -104,11 +108,11 @@ class TestTextExtractor:
         mock_reader_instance.pages[0].extract_text.return_value = "Page 1 content"
         mock_reader_instance.pages[1].extract_text.return_value = "Page 2 content"
 
-        mock_pdf_reader = mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader")
+        mock_pdf_reader = mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader")
         mock_pdf_reader.return_value = mock_reader_instance
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pdf(Path(tmp.name))
+            result = pdf_extractor.extract_text(Path(tmp.name))
             assert result == "Page 1 content\n\nPage 2 content"
 
         # Clean up
@@ -119,12 +123,12 @@ class TestTextExtractor:
         mock_reader_instance = mocker.MagicMock()
         mock_reader_instance.is_encrypted = True
 
-        mock_pdf_reader = mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader")
+        mock_pdf_reader = mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader")
         mock_pdf_reader.return_value = mock_reader_instance
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="PDF file is encrypted"):
-                self.extractor.extract_text_from_pdf(Path(tmp.name))
+                pdf_extractor.extract_text(Path(tmp.name))
 
         # Clean up
         Path(tmp.name).unlink()
@@ -135,10 +139,10 @@ class TestTextExtractor:
         mock_reader_instance.pages = []  # No pages
         mock_reader_instance.is_encrypted = False
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader", return_value=mock_reader_instance)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader", return_value=mock_reader_instance)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pdf(Path(tmp.name))
+            result = pdf_extractor.extract_text(Path(tmp.name))
             assert result == ""
 
         Path(tmp.name).unlink()
@@ -150,14 +154,14 @@ class TestTextExtractor:
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Permission denied"):
-                self.extractor.extract_text_from_pdf(Path(tmp.name))
+                pdf_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
     def test_extract_text_from_pdf_file_not_found(self):
         """Test PDF extraction from non-existent file."""
         with pytest.raises(TextExtractionError, match="PDF file not found"):
-            self.extractor.extract_text_from_pdf(Path("nonexistent.pdf"))
+            pdf_extractor.extract_text(Path("nonexistent.pdf"))
 
     def test_extract_text_from_docx_success(self, mocker):
         """Test successful DOCX text extraction."""
@@ -170,11 +174,11 @@ class TestTextExtractor:
         mock_doc.paragraphs = [mock_paragraph1, mock_paragraph2]
         mock_doc.tables = []
 
-        mock_document = mocker.patch("src.document_to_anki.utils.text_extractor.Document")
+        mock_document = mocker.patch("src.document_to_anki.utils.docx_extractor.Document")
         mock_document.return_value = mock_doc
 
         with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
-            result = self.extractor.extract_text_from_docx(Path(tmp.name))
+            result = docx_extractor.extract_text(Path(tmp.name))
             assert result == "First paragraph\n\nSecond paragraph"
 
         # Clean up
@@ -183,25 +187,25 @@ class TestTextExtractor:
     def test_extract_text_from_docx_file_not_found(self):
         """Test DOCX extraction from non-existent file."""
         with pytest.raises(TextExtractionError, match="Unexpected error extracting from DOCX"):
-            self.extractor.extract_text_from_docx(Path("nonexistent.docx"))
+            docx_extractor.extract_text(Path("nonexistent.docx"))
 
     def test_extract_text_from_docx_permission_error(self, mocker):
         """Test DOCX extraction with permission error."""
-        mocker.patch("src.document_to_anki.utils.text_extractor.Document", side_effect=PermissionError("Access denied"))
+        mocker.patch("src.document_to_anki.utils.docx_extractor.Document", side_effect=PermissionError("Access denied"))
 
         with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Permission denied"):
-                self.extractor.extract_text_from_docx(Path(tmp.name))
+                docx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
     def test_extract_text_from_docx_corrupted_file(self, mocker):
         """Test DOCX extraction from corrupted file."""
-        mocker.patch("src.document_to_anki.utils.text_extractor.Document", side_effect=Exception("not a zip file"))
+        mocker.patch("src.document_to_anki.utils.docx_extractor.Document", side_effect=Exception("not a zip file"))
 
         with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Invalid or corrupted DOCX file"):
-                self.extractor.extract_text_from_docx(Path(tmp.name))
+                docx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -211,10 +215,10 @@ class TestTextExtractor:
         mock_doc.paragraphs = []
         mock_doc.tables = []
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.Document", return_value=mock_doc)
+        mocker.patch("src.document_to_anki.utils.docx_extractor.Document", return_value=mock_doc)
 
         with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
-            result = self.extractor.extract_text_from_docx(Path(tmp.name))
+            result = docx_extractor.extract_text(Path(tmp.name))
             assert result == ""
 
         Path(tmp.name).unlink()
@@ -236,7 +240,7 @@ class TestTextExtractor:
     def test_extract_text_exception_handling(self, mocker):
         """Test exception handling in extract_text method."""
         # Mock extract_text_from_txt to raise a non-TextExtractionError
-        mocker.patch.object(self.extractor, "extract_text_from_txt", side_effect=ValueError("Unexpected error"))
+        mocker.patch("src.document_to_anki.utils.text_extractor_common.extract_text", side_effect=ValueError("Unexpected error"))
 
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp:
             tmp.write(b"test content")
@@ -259,27 +263,27 @@ class TestTextExtractor:
     def test_extract_text_from_pdf_reader_initialization_error(self, mocker):
         """Test PDF extraction when PdfReader initialization fails completely."""
         # Mock PdfReader to raise an exception on initialization
-        mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader", side_effect=Exception("PDF reader failed"))
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader", side_effect=Exception("PDF reader failed"))
         # Mock HAS_PDFPLUMBER to False to test the error path
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", False)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", False)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Could not initialize PDF reader"):
-                self.extractor.extract_text_from_pdf(Path(tmp.name))
+                pdf_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
     def test_extract_text_from_pdf_with_pdfplumber_fallback(self, mocker):
         """Test PDF extraction falling back to pdfplumber when pypdf fails."""
         # Mock pypdf to fail
-        mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader", side_effect=Exception("pypdf failed"))
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader", side_effect=Exception("pypdf failed"))
         # Mock HAS_PDFPLUMBER to True
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", True)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", True)
         # Mock the pdfplumber fallback method
-        mock_fallback = mocker.patch.object(self.extractor, "_extract_with_pdfplumber", return_value="Fallback text")
+        mock_fallback = mocker.patch("src.document_to_anki.utils.pdf_extractor._extract_with_pdfplumber", return_value="Fallback text")
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pdf(Path(tmp.name))
+            result = pdf_extractor.extract_text(Path(tmp.name))
             assert result == "Fallback text"
             mock_fallback.assert_called_once_with(Path(tmp.name))
 
@@ -302,10 +306,10 @@ class TestTextExtractor:
 
         mock_reader_instance.pages = [mock_page1, mock_page2, mock_page3]
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader", return_value=mock_reader_instance)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader", return_value=mock_reader_instance)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pdf(Path(tmp.name))
+            result = pdf_extractor.extract_text(Path(tmp.name))
             assert result == "Good page content\n\nAnother good page"
 
         Path(tmp.name).unlink()
@@ -324,11 +328,11 @@ class TestTextExtractor:
 
         mock_reader_instance.pages = [mock_page1, mock_page2]
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader", return_value=mock_reader_instance)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader", return_value=mock_reader_instance)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="No text content could be extracted from PDF"):
-                self.extractor.extract_text_from_pdf(Path(tmp.name))
+                pdf_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -336,11 +340,11 @@ class TestTextExtractor:
         """Test PDF extraction with PDF-specific errors."""
         # Mock to raise a PDF-specific error
         pdf_error = Exception("PdfReadError: Invalid PDF")
-        mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader", side_effect=pdf_error)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader", side_effect=pdf_error)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Invalid or corrupted PDF file"):
-                self.extractor.extract_text_from_pdf(Path(tmp.name))
+                pdf_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -356,11 +360,11 @@ class TestTextExtractor:
 
         mock_pdfplumber = mocker.MagicMock()
         mock_pdfplumber.open.return_value.__enter__.return_value = mock_pdf
-        mocker.patch("src.document_to_anki.utils.text_extractor.pdfplumber", mock_pdfplumber)
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", True)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.pdfplumber", mock_pdfplumber)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            result = self.extractor._extract_with_pdfplumber(Path(tmp.name))
+            result = pdf_extractor._extract_with_pdfplumber(Path(tmp.name))
             assert result == "Page 1 from pdfplumber\n\nPage 2 from pdfplumber"
 
         Path(tmp.name).unlink()
@@ -368,11 +372,11 @@ class TestTextExtractor:
     def test_extract_with_pdfplumber_not_available(self, mocker):
         """Test pdfplumber extraction when pdfplumber is not available."""
         # Mock HAS_PDFPLUMBER to False to simulate pdfplumber not being available
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", False)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", False)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="pdfplumber is not available"):
-                self.extractor._extract_with_pdfplumber(Path(tmp.name))
+                pdf_extractor._extract_with_pdfplumber(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -403,10 +407,10 @@ class TestTextExtractor:
         mock_table.rows = [mock_row1, mock_row2]
         mock_doc.tables = [mock_table]
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.Document", return_value=mock_doc)
+        mocker.patch("src.document_to_anki.utils.docx_extractor.Document", return_value=mock_doc)
 
         with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
-            result = self.extractor.extract_text_from_docx(Path(tmp.name))
+            result = docx_extractor.extract_text(Path(tmp.name))
             assert result == "Document paragraph\n\nCell 1 | Cell 2"
 
         Path(tmp.name).unlink()
@@ -431,7 +435,7 @@ class TestTextExtractor:
 
             mocker.patch("builtins.open", side_effect=mock_open)
 
-            result = self.extractor.extract_text_from_txt(Path(tmp.name))
+            result = text_extractor_common.extract_text(Path(tmp.name))
             # The result should be the content (may have encoding differences)
             assert len(result) > 0
 
@@ -444,7 +448,7 @@ class TestTextExtractor:
 
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Could not decode text file with any supported encoding"):
-                self.extractor.extract_text_from_txt(Path(tmp.name))
+                text_extractor_common.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -454,7 +458,7 @@ class TestTextExtractor:
 
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Permission denied accessing text file"):
-                self.extractor.extract_text_from_txt(Path(tmp.name))
+                text_extractor_common.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -466,7 +470,7 @@ class TestTextExtractor:
         mock_reader_instance.pages = [mocker.MagicMock()]
         mock_reader_instance.pages[0].extract_text.return_value = "PDF integration test"
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.PdfReader", return_value=mock_reader_instance)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.PdfReader", return_value=mock_reader_instance)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             result = self.extractor.extract_text(Path(tmp.name))
@@ -483,7 +487,7 @@ class TestTextExtractor:
         mock_doc.paragraphs = [mock_paragraph]
         mock_doc.tables = []
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.Document", return_value=mock_doc)
+        mocker.patch("src.document_to_anki.utils.docx_extractor.Document", return_value=mock_doc)
 
         with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
             result = self.extractor.extract_text(Path(tmp.name))
@@ -511,11 +515,11 @@ class TestTextExtractor:
 
         mock_pdfplumber = mocker.MagicMock()
         mock_pdfplumber.open.return_value.__enter__.return_value = mock_pdf
-        mocker.patch("src.document_to_anki.utils.text_extractor.pdfplumber", mock_pdfplumber)
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", True)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.pdfplumber", mock_pdfplumber)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            result = self.extractor._extract_with_pdfplumber(Path(tmp.name))
+            result = pdf_extractor._extract_with_pdfplumber(Path(tmp.name))
             assert result == ""
 
         Path(tmp.name).unlink()
@@ -531,14 +535,14 @@ class TestTextExtractor:
 
         mock_pdfplumber = mocker.MagicMock()
         mock_pdfplumber.open.return_value.__enter__.return_value = mock_pdf
-        mocker.patch("src.document_to_anki.utils.text_extractor.pdfplumber", mock_pdfplumber)
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", True)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.pdfplumber", mock_pdfplumber)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(
                 TextExtractionError, match="No text content could be extracted from PDF using pdfplumber"
             ):
-                self.extractor._extract_with_pdfplumber(Path(tmp.name))
+                pdf_extractor._extract_with_pdfplumber(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -555,11 +559,11 @@ class TestTextExtractor:
 
         mock_pdfplumber = mocker.MagicMock()
         mock_pdfplumber.open.return_value.__enter__.return_value = mock_pdf
-        mocker.patch("src.document_to_anki.utils.text_extractor.pdfplumber", mock_pdfplumber)
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", True)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.pdfplumber", mock_pdfplumber)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            result = self.extractor._extract_with_pdfplumber(Path(tmp.name))
+            result = pdf_extractor._extract_with_pdfplumber(Path(tmp.name))
             assert result == "Good page\n\nAnother good page"
 
         Path(tmp.name).unlink()
@@ -568,22 +572,22 @@ class TestTextExtractor:
         """Test pdfplumber extraction with general exception."""
         mock_pdfplumber = mocker.MagicMock()
         mock_pdfplumber.open.side_effect = Exception("pdfplumber failed")
-        mocker.patch("src.document_to_anki.utils.text_extractor.pdfplumber", mock_pdfplumber)
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PDFPLUMBER", True)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.pdfplumber", mock_pdfplumber)
+        mocker.patch("src.document_to_anki.utils.pdf_extractor.HAS_PDFPLUMBER", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="pdfplumber extraction failed"):
-                self.extractor._extract_with_pdfplumber(Path(tmp.name))
+                pdf_extractor._extract_with_pdfplumber(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
     def test_extract_text_from_docx_file_not_found_specific(self, mocker):
         """Test DOCX extraction with specific file not found error."""
-        mocker.patch("src.document_to_anki.utils.text_extractor.Document", side_effect=Exception("no such file"))
+        mocker.patch("src.document_to_anki.utils.docx_extractor.Document", side_effect=Exception("no such file"))
 
         with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="DOCX file not found"):
-                self.extractor.extract_text_from_docx(Path(tmp.name))
+                docx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -612,14 +616,14 @@ class TestTextExtractor:
         mock_presentation.slides = [mock_slide1, mock_slide2]
 
         # Mock the Presentation class
-        mock_presentation_class = mocker.patch("src.document_to_anki.utils.text_extractor.Presentation")
+        mock_presentation_class = mocker.patch("src.document_to_anki.utils.pptx_extractor.Presentation")
         mock_presentation_class.return_value = mock_presentation
 
         # Mock HAS_PPTX to True
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pptx(Path(tmp.name))
+            result = pptx_extractor.extract_text(Path(tmp.name))
 
             # Verify the structure is preserved
             assert "=== Slide 1 ===" in result
@@ -635,11 +639,11 @@ class TestTextExtractor:
     def test_extract_text_from_pptx_not_available(self, mocker):
         """Test PPTX extraction when python-pptx is not available."""
         # Mock HAS_PPTX to False
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", False)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", False)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="python-pptx is not available"):
-                self.extractor.extract_text_from_pptx(Path(tmp.name))
+                pptx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -648,12 +652,12 @@ class TestTextExtractor:
         mock_presentation = mocker.MagicMock()
         mock_presentation.slides = []  # No slides
 
-        mock_presentation_class = mocker.patch("src.document_to_anki.utils.text_extractor.Presentation")
+        mock_presentation_class = mocker.patch("src.document_to_anki.utils.pptx_extractor.Presentation")
         mock_presentation_class.return_value = mock_presentation
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pptx(Path(tmp.name))
+            result = pptx_extractor.extract_text(Path(tmp.name))
             assert result == ""
 
         Path(tmp.name).unlink()
@@ -672,13 +676,13 @@ class TestTextExtractor:
         mock_slide.shapes = [mock_shape1, mock_shape2]
         mock_presentation.slides = [mock_slide]
 
-        mock_presentation_class = mocker.patch("src.document_to_anki.utils.text_extractor.Presentation")
+        mock_presentation_class = mocker.patch("src.document_to_anki.utils.pptx_extractor.Presentation")
         mock_presentation_class.return_value = mock_presentation
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="No text content could be extracted from PowerPoint"):
-                self.extractor.extract_text_from_pptx(Path(tmp.name))
+                pptx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -698,12 +702,12 @@ class TestTextExtractor:
         mock_slide.shapes = [mock_shape_with_text, mock_shape_without_text]
         mock_presentation.slides = [mock_slide]
 
-        mock_presentation_class = mocker.patch("src.document_to_anki.utils.text_extractor.Presentation")
+        mock_presentation_class = mocker.patch("src.document_to_anki.utils.pptx_extractor.Presentation")
         mock_presentation_class.return_value = mock_presentation
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pptx(Path(tmp.name))
+            result = pptx_extractor.extract_text(Path(tmp.name))
             assert "=== Slide 1 ===" in result
             assert "Valid text content" in result
 
@@ -731,12 +735,12 @@ class TestTextExtractor:
 
         mock_presentation.slides = [mock_slide1, mock_slide2, mock_slide3]
 
-        mock_presentation_class = mocker.patch("src.document_to_anki.utils.text_extractor.Presentation")
+        mock_presentation_class = mocker.patch("src.document_to_anki.utils.pptx_extractor.Presentation")
         mock_presentation_class.return_value = mock_presentation
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
-            result = self.extractor.extract_text_from_pptx(Path(tmp.name))
+            result = pptx_extractor.extract_text(Path(tmp.name))
             assert "Good slide content" in result
             assert "Another good slide" in result
             # Slide 2 should be skipped due to error
@@ -746,55 +750,55 @@ class TestTextExtractor:
     def test_extract_text_from_pptx_file_not_found(self):
         """Test PPTX extraction from non-existent file."""
         with pytest.raises(TextExtractionError, match="PowerPoint file not found"):
-            self.extractor.extract_text_from_pptx(Path("nonexistent.pptx"))
+            pptx_extractor.extract_text(Path("nonexistent.pptx"))
 
     def test_extract_text_from_pptx_permission_error(self, mocker):
         """Test PPTX extraction with permission error."""
         mocker.patch(
-            "src.document_to_anki.utils.text_extractor.Presentation", side_effect=PermissionError("Access denied")
+            "src.document_to_anki.utils.pptx_extractor.Presentation", side_effect=PermissionError("Access denied")
         )
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Permission denied accessing PowerPoint file"):
-                self.extractor.extract_text_from_pptx(Path(tmp.name))
+                pptx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
     def test_extract_text_from_pptx_corrupted_file(self, mocker):
         """Test PPTX extraction from corrupted file."""
-        mocker.patch("src.document_to_anki.utils.text_extractor.Presentation", side_effect=Exception("not a zip file"))
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.Presentation", side_effect=Exception("not a zip file"))
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Invalid or corrupted PowerPoint file"):
-                self.extractor.extract_text_from_pptx(Path(tmp.name))
+                pptx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
     def test_extract_text_from_pptx_password_protected(self, mocker):
         """Test PPTX extraction from password-protected file."""
         mocker.patch(
-            "src.document_to_anki.utils.text_extractor.Presentation", side_effect=Exception("password protected")
+            "src.document_to_anki.utils.pptx_extractor.Presentation", side_effect=Exception("password protected")
         )
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Password-protected PowerPoint file"):
-                self.extractor.extract_text_from_pptx(Path(tmp.name))
+                pptx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
     def test_extract_text_from_pptx_unexpected_error(self, mocker):
         """Test PPTX extraction with unexpected error."""
         mocker.patch(
-            "src.document_to_anki.utils.text_extractor.Presentation", side_effect=Exception("Unexpected error")
+            "src.document_to_anki.utils.pptx_extractor.Presentation", side_effect=Exception("Unexpected error")
         )
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
             with pytest.raises(TextExtractionError, match="Unexpected error extracting from PowerPoint"):
-                self.extractor.extract_text_from_pptx(Path(tmp.name))
+                pptx_extractor.extract_text(Path(tmp.name))
 
         Path(tmp.name).unlink()
 
@@ -802,34 +806,34 @@ class TestTextExtractor:
         """Test _clean_slide_text helper method."""
         # Test with normal text
         text = "Title\n\nContent line 1\nContent line 2\n\n\n"
-        result = self.extractor._clean_slide_text(text)
+        result = pptx_extractor._clean_slide_text(text)
         assert result == "Title\n\nContent line 1\nContent line 2"
 
         # Test with excessive whitespace
         text = "  Title  \n\n  \n  Content  \n  \n\n\n"
-        result = self.extractor._clean_slide_text(text)
+        result = pptx_extractor._clean_slide_text(text)
         assert result == "Title\n\nContent"
 
         # Test with bullet points
         text = "• Bullet 1\n• Bullet 2\n\n• Bullet 3"
-        result = self.extractor._clean_slide_text(text)
+        result = pptx_extractor._clean_slide_text(text)
         assert result == "• Bullet 1\n• Bullet 2\n\n• Bullet 3"
 
     def test_clean_slide_text_empty_input(self):
         """Test _clean_slide_text with empty or whitespace-only input."""
         # Test with empty string
-        assert self.extractor._clean_slide_text("") == ""
+        assert pptx_extractor._clean_slide_text("") == ""
 
         # Test with None
-        assert self.extractor._clean_slide_text(None) == ""
+        assert pptx_extractor._clean_slide_text(None) == ""
 
         # Test with only whitespace
-        assert self.extractor._clean_slide_text("   \n\n   ") == ""
+        assert pptx_extractor._clean_slide_text("   \n\n   ") == ""
 
     def test_clean_slide_text_multiple_newlines(self):
         """Test _clean_slide_text removes excessive newlines."""
         text = "Line 1\n\n\n\n\nLine 2\n\n\n\nLine 3"
-        result = self.extractor._clean_slide_text(text)
+        result = pptx_extractor._clean_slide_text(text)
         assert result == "Line 1\n\nLine 2\n\nLine 3"
 
     def test_extract_text_integration_pptx(self, mocker):
@@ -842,8 +846,8 @@ class TestTextExtractor:
         mock_slide.shapes = [mock_shape]
         mock_presentation.slides = [mock_slide]
 
-        mocker.patch("src.document_to_anki.utils.text_extractor.Presentation", return_value=mock_presentation)
-        mocker.patch("src.document_to_anki.utils.text_extractor.HAS_PPTX", True)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.Presentation", return_value=mock_presentation)
+        mocker.patch("src.document_to_anki.utils.pptx_extractor.HAS_PPTX", True)
 
         with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as tmp:
             result = self.extractor.extract_text(Path(tmp.name))


### PR DESCRIPTION
## Summary
- split PDF, DOCX, PPTX, and text helpers into dedicated extractor modules
- delegate `TextExtractor` to new modules with shared interface
- adjust unit tests for new module layout

## Testing
- `pre-commit run --files src/document_to_anki/utils/text_extractor.py src/document_to_anki/utils/pdf_extractor.py src/document_to_anki/utils/docx_extractor.py src/document_to_anki/utils/pptx_extractor.py src/document_to_anki/utils/text_extractor_common.py tests/test_text_extractor.py` *(command not found)*
- `pip install pre-commit` *(ProxyError: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_text_extractor.py` *(ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68ade734d890832599fa281189c63313