### PR TITLE
fix(tests): decouple two tests from local .env so CI passes

### DIFF
--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from src.document_to_anki.config import settings
 from src.document_to_anki.utils.file_handler import FileHandler, FileHandlingError
 
 
@@ -21,7 +22,8 @@ class TestFileHandler:
         handler = FileHandler()
         assert handler.processed_files == []
         assert handler.SUPPORTED_EXTENSIONS == {".pdf", ".docx", ".pptx", ".txt", ".md"}
-        assert handler.MAX_FILE_SIZE == 500 * 1024 * 1024  # Current config value
+        # Read from configuration so the test is independent of the local .env / CI env.
+        assert handler.MAX_FILE_SIZE == settings.max_file_size_bytes
         assert handler.MAX_FILES_COUNT == 100
 
     def test_validate_file_type_supported_extensions(self):

--- a/tests/test_web_language_integration.py
+++ b/tests/test_web_language_integration.py
@@ -46,7 +46,8 @@ class TestWebLanguageIntegration:
 
     def test_home_page_displays_language_info(self, client, mocker):
         """Test that home page displays current language configuration."""
-        mock_settings = mocker.patch("src.document_to_anki.web.app.settings")
+        # The home page is served by routes_upload, which reads its own `settings`.
+        mock_settings = mocker.patch("src.document_to_anki.web.routes_upload.settings")
 
         # Mock language info
         mock_language_info = mocker.MagicMock()


### PR DESCRIPTION
## Problem
The v0.1.0 release CI (and merge to main) failed the **Test Suite** job: 2 failed, 461 passed. Both tests assert the developer's local `.env` values, which CI (no `.env`) doesn't have:

- `test_file_handler::test_init` expected `MAX_FILE_SIZE == 500MB` (from `.env` `MAX_FILE_SIZE_MB=500`); CI default is 50MB.
- `test_home_page_displays_language_info` patched `web.app.settings`, but `/` is served by `routes_upload` (its own `settings`); locally `.env` `CARDLANG=fr` masked the wrong patch target.

These are env-coupling bugs (pre-existing for the first; same RC-3 mis-targeting family for the second), not code defects — `src/` is unchanged.

## Fix
- Assert `handler.MAX_FILE_SIZE == settings.max_file_size_bytes` (env-independent).
- Patch `routes_upload.settings` for the home-page test (the module the route actually reads).

## Verification
Full suite run with `.env` removed (mirrors CI): **463 passed**. `ruff` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)