### PR TITLE
chore(release): bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "document-to-anki-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "Convert documents to Anki flashcards using AI - supports PDF, DOCX, TXT, MD files with both CLI and web interfaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/document_to_anki/__init__.py
+++ b/src/document_to_anki/__init__.py
@@ -52,7 +52,7 @@ Configuration:
     Set GEMINI_API_KEY environment variable or create .env file
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__ = "Document to Anki CLI Team"
 __email__ = "support@document-to-anki.com"
 __license__ = "MIT"

--- a/src/document_to_anki/cli/main.py
+++ b/src/document_to_anki/cli/main.py
@@ -218,7 +218,7 @@ def main(ctx: click.Context, verbose: bool, version: bool) -> None:
     Example: export CARDLANG=french && document-to-anki input.pdf
     """
     if version:
-        click.echo("Document to Anki CLI v0.1.0")
+        click.echo("Document to Anki CLI v0.1.1")
         return
 
     # Create CLI context - this will validate model configuration

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -163,7 +163,7 @@ class TestCLIIntegration:
         result = runner.invoke(main, ["--version"])
 
         assert result.exit_code == 0
-        assert "Document to Anki CLI v0.1.0" in result.output
+        assert "Document to Anki CLI v0.1.1" in result.output
 
     def test_convert_command_help(self, runner):
         """Test convert command help."""

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "document-to-anki-cli"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release for the dependency-hygiene cleanup (#7). Version-string bump only (pyproject, `__version__`, CLI `--version`, and its test). 463 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)