### PR TITLE
chore: fleet health refresh

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,3 +81,6 @@ validation:
     omitted_files: ignore
   links:
     unrecognized_links: ignore
+
+extra:
+  version: v0.1.1


### PR DESCRIPTION
Fleet health audit + refresh (docs-only).

- mkdocs — refreshed: canonical repo_url/repo_name + mkdocs-material `extra.version` = v0.1.1
- Release n/a (no publish mechanism).

No application-code changes.