### PR TITLE
docs(readme): add standard status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Document to Anki CLI
 
+[![CI](https://github.com/fjacquet/anki-maker/actions/workflows/ci.yml/badge.svg)](https://github.com/fjacquet/anki-maker/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/fjacquet/anki-maker?sort=semver)](https://github.com/fjacquet/anki-maker/releases/latest)
+[![License](https://img.shields.io/github/license/fjacquet/anki-maker)](https://github.com/fjacquet/anki-maker/blob/HEAD/LICENSE)
+
 Convert documents to Anki flashcards using AI-powered content analysis.
 
 


### PR DESCRIPTION
Adds the standard README badge set (CI + latest release + license where applicable) to match the rest of the fleet. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added status badges to the README, including GitHub Actions CI status, release version, and license badges, each linking to the corresponding repository pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->