### PR TITLE
build: fully qualify base image names for Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Document to Anki CLI - Docker Image
-FROM python:3.12-slim
+FROM docker.io/library/python:3.12-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
Preparation for the Docker→Podman move.

Podman resolves unqualified image names via `unqualified-search-registries` in `registries.conf`. On RHEL/Fedora that list does not start with `docker.io`, and under `short-name-mode="enforcing"` an unqualified name fails outright in a non-interactive build. Docker always implies `docker.io/library`.

Every base image is now fully qualified. Already-qualified refs (`ghcr.io/*`, `gcr.io/*`, `registry.access.redhat.com/*`), `FROM scratch`, and inter-stage `FROM <stage>` references are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)